### PR TITLE
[Fix] 팀목록 조회시 로그인하지 않은 경우 목록이 조회되지 않는 버그 해결 - 로그인하지 않았을때 storage에 값이 …

### DIFF
--- a/src/components/team/TeamComp.vue
+++ b/src/components/team/TeamComp.vue
@@ -73,6 +73,10 @@ import storageUtil from '@/common/StorageUtil.js';
             },
             isTeamMember(teamSeq) {
                 const userInfo = storageUtil.getAuthUserFromSession();
+                if (userInfo == null) {
+                    return false;
+                }
+                
                 const joinedTeamSeqList = Object.keys(userInfo.userAuth);
 
                 let isTeamMember = false;


### PR DESCRIPTION
…없음. null체크 추가