### PR TITLE
[Fix] TeamInfoFormComp 컴포넌트 오류 해결 ( teamLogoImage URL이 prop를 참조하고 있었음…

### DIFF
--- a/src/components/team/TeamInfoFormComp.vue
+++ b/src/components/team/TeamInfoFormComp.vue
@@ -35,7 +35,7 @@
 				</v-col>
 				<v-col cols="5">
 					<MyTeamImage
-						:pImageUrl="this.pTeamInfo.logoImageUrl"
+						:pImageUrl="teamInfo.logoImageUrl"
 						:pMaxHeight="String(250)"
 						:pMaxWidth="String(250)"
 					/>
@@ -134,6 +134,13 @@
 		components: {
 			MyTeamImage,
 			CustomDatePickerComp,
+		},
+		mounted() {
+			// 화면 초기화에 사용할 데이터를 props로 받을 경우 data에 세팅 ( 팀정보 수정인 경우에 해당 )
+			if (this.pTeamInfo != null) {
+				this.teamInfo = this.pTeamInfo;
+				return;
+			}
 		},
 		data() {
 			return {
@@ -237,11 +244,6 @@
 				this.teamInfo.teamLogoImage = imageFile;
 				this.$emit('e-team-info', this.teamInfo);
 			},
-		},
-		mounted() {
-			if (this.pTeamInfo != null) {
-				this.teamInfo = this.pTeamInfo;
-			}
 		},
 	};
 </script>


### PR DESCRIPTION
…. 팀등록 화면의 경우 prop가 null이기 떄문에 오류 발생함